### PR TITLE
chore: rename 'jupiter' package in 'reactive'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <gravitee-apim-gateway-tests-sdk.version>3.21.0-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
         <gravitee-bom.version>3.0.0</gravitee-bom.version>
-        <gravitee-gateway-api.version>2.1.0-alpha.6</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>2.1.0-alpha.20</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <json-schema-generator-maven-plugin.version>1.1.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>

--- a/src/main/java/io/gravitee/policy/overriderequestmethod/OverrideRequestMethodPolicy.java
+++ b/src/main/java/io/gravitee/policy/overriderequestmethod/OverrideRequestMethodPolicy.java
@@ -17,9 +17,9 @@ package io.gravitee.policy.overriderequestmethod;
 
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.gateway.api.ExecutionContext;
-import io.gravitee.gateway.jupiter.api.context.ContextAttributes;
-import io.gravitee.gateway.jupiter.api.context.HttpExecutionContext;
-import io.gravitee.gateway.jupiter.api.policy.Policy;
+import io.gravitee.gateway.reactive.api.context.ContextAttributes;
+import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
+import io.gravitee.gateway.reactive.api.policy.Policy;
 import io.gravitee.policy.overriderequestmethod.configuration.OverrideRequestMethodPolicyConfiguration;
 import io.gravitee.policy.v3.overriderequestmethod.OverrideRequestMethodPolicyV3;
 import io.reactivex.rxjava3.core.Completable;

--- a/src/test/resources/apis/v4_definition/override-http-method.json
+++ b/src/test/resources/apis/v4_definition/override-http-method.json
@@ -3,7 +3,8 @@
   "name": "override-request-method",
   "apiVersion": "1.0",
   "definitionVersion": "4.0.0",
-  "type": "sync",
+  "type": "proxy",
+  "analytics": {},
   "description": "override-request-method",
   "listeners": [
     {


### PR DESCRIPTION
related-ti APIM-718
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-apim-718-rename-v4-terms-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-override-http-method/2.0.0-apim-718-rename-v4-terms-SNAPSHOT/gravitee-policy-override-http-method-2.0.0-apim-718-rename-v4-terms-SNAPSHOT.zip)
  <!-- Version placeholder end -->
