### PR TITLE
chore: bump gravitee orb and set alpha pattern

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,13 +30,13 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.5</version>
+        <version>21.0.0</version>
     </parent>
 
     <properties>
         <gravitee-apim-gateway-tests-sdk.version>3.21.0-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
-        <gravitee-bom.version>3.0.0</gravitee-bom.version>
-        <gravitee-gateway-api.version>2.1.0-alpha.20</gravitee-gateway-api.version>
+        <gravitee-bom.version>4.0.0</gravitee-bom.version>
+        <gravitee-gateway-api.version>2.1.0</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <json-schema-generator-maven-plugin.version>1.1.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-bump-dependencies-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-override-http-method/2.0.0-bump-dependencies-SNAPSHOT/gravitee-policy-override-http-method-2.0.0-bump-dependencies-SNAPSHOT.zip)
  <!-- Version placeholder end -->
